### PR TITLE
Include license file in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
It is very important to include a license file in sdists for legal reasons.