### PR TITLE
Set long_description content type in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     url='https://github.com/jankatins/pytest-error-for-skips',
     description='Pytest plugin to treat skipped tests a test failure',
     long_description=read('README.md'),
+    long_description_content_type='text/markdown',
     py_modules=['pytest_error_for_skips'],
     install_requires=['pytest>=5'],
     python_requires='>=3.5',


### PR DESCRIPTION
PyPI defaults to restructured text so you have to set the content type for the page to display markdown correctly:

https://pypi.org/project/pytest-error-for-skips/